### PR TITLE
Ayshajamjam

### DIFF
--- a/index.css
+++ b/index.css
@@ -75,6 +75,7 @@ canvas {
 
 .tooltip:hover .tooltiptext {
   visibility: visible;
+  padding: 10px;
 }
 
 .center {

--- a/index.html
+++ b/index.html
@@ -61,13 +61,13 @@
 			<!-- <p>Bit size: <span id="printSize"></span></p> -->
 
 			<div class="tooltip">
-				Bit size:
+				Bit Size:
 				<span class="tooltiptext"
-					>Larger sizes hide more of the image, but are easier to
+					>Larger sizes hide more of the image but are easier to
 					scan. I found that a size of 30 works well.</span
 				>
-				<span id="printSize"></span>
 			</div>
+			<span id="printSize"></span>
 
 			<br /><br />
 
@@ -87,12 +87,12 @@
 			<div class="tooltip">
 				Error Correction:
 				<span class="tooltiptext"
-					>Higher level of error correction makes bigger qr codes, but
+					>Higher level of error correction makes bigger QR codes, but
 					also allows you to hide more of the QR code. The former is
 					more relevant to this app.</span
 				>
-				<span id="printCorrection"></span>
 			</div>
+			<span id="printCorrection"></span>
 
 			<br /><br />
 
@@ -116,8 +116,8 @@
 					border around the code, but depending on your use case you
 					can get rid of it.</span
 				>
-				<span id="printBorderSize"></span>
 			</div>
+			<span id="printBorderSize"></span>
 
 			<br /><br />
 
@@ -134,14 +134,29 @@
 
 			<br />
 
+			<p>Select Background (default is transparent):</p>
+			
 			<input
 				type="checkbox"
 				id="whitebackground"
 				name="whitebackground"
 			/>
 			<label for="whitebackground">White background</label><br />
+			<input
+				type="checkbox"
+				id="blackbackground"
+				name="blackbackground"
+			/>
+			<label for="blackbackground">Black background</label><br /><br />
+			<input
+				type="checkbox"
+				id="custombackground"
+				name="custombackground"
+			/>
+			<label for="custombackground"> Custom background color picker:</label>
+			<input type="color" id="colorpicker" value="#fff000">
 
-			<br />
+			<br /><br />
 
 			<div class="center">
 				<button
@@ -165,9 +180,16 @@
 				<button
 					class="w3-button w3-white w3-border w3-border-blue"
 					style="margin: 0 auto"
-					onclick="download()"
+					onclick="download('png')"
 				>
 					Download PNG
+				</button>
+				<button
+					class="w3-button w3-white w3-border w3-border-blue"
+					style="margin: 0 auto"
+					onclick="download('jpeg')"
+				>
+					Download JPEG
 				</button>
 			</div>
 

--- a/index.js
+++ b/index.js
@@ -153,21 +153,44 @@ function drawShape(ctx, i, j, bitLength, radiusRatio, QRLength) {
 }
 
 /**
- * Download the QR code as a PNG
+ * Download the QR code as a PNG or JPEG
  */
-function download() {
+function download(format) {
   // Download image
   if (!canvas) {
     alert("Error: no QR code to download");
     return;
   }
   var link = document.getElementById("link");
-  link.setAttribute("download", "qr_image.png");
-  link.setAttribute(
-    "href",
-    canvas.toDataURL("image/png").replace("image/png", "image/octet-stream")
-  );
+
+  if(format == 'png'){
+    link.setAttribute("download", "qr_image.png");
+    link.setAttribute(
+      "href",
+      canvas.toDataURL("image/png").replace("image/png", "image/octet-stream")
+    );
+  }
+  if(format == 'jpeg'){
+    link.setAttribute("download", "qr_image.jpeg");
+    link.setAttribute(
+      "href",
+      canvas.toDataURL("image/jpeg").replace("image/jpeg", "image/octet-stream")
+    );
+  }
   link.click();
+}
+
+/**
+ * Validate URL inputted by user
+ */
+function isValidUrl(str) {
+  try {
+    new URL(str);
+    return true;
+  }
+  catch (err) {
+    return false;
+  }
 }
 
 /**
@@ -180,7 +203,14 @@ function makeCode() {
 
   // Check for non-empty url
   if (!url) {
-    alert("Error: empty input");
+    alert("Error: please input a URL");
+    elementText.focus();
+    return;
+  }
+
+  // Check for valid URL input
+  if (!isValidUrl(url)) {
+    alert("Error: please input a valid URL");
     elementText.focus();
     return;
   }
@@ -211,6 +241,16 @@ function makeCode() {
   // Set background of canvas
   if (document.getElementById("whitebackground").checked) {
     ctx.fillStyle = "#FFFFFF";
+    ctx.fillRect(0, 0, canvasLength, canvasLength);
+    document.getElementById("colorpicker").value = '#FFFFFF';
+  }
+  else if (document.getElementById("blackbackground").checked){
+    ctx.fillStyle = "#000000";
+    ctx.fillRect(0, 0, canvasLength, canvasLength);
+    document.getElementById("colorpicker").value = '#000000';
+  }
+  else if (document.getElementById("custombackground").checked){
+    ctx.fillStyle = document.getElementById("colorpicker").value;
     ctx.fillRect(0, 0, canvasLength, canvasLength);
   }
 


### PR DESCRIPTION
By ayshajamjam

> These are the changes I made:
> 
> **Grammar/clean up:**
> 
>     1. Bit size —> Bit Size
> 
>     2. qr —> QR
> 
>     3. Fixed grammar
> 
> 
> **URL Error:**
> 
>     * When user does not include a URL, the alert box just says “Error: empty input”. I wanted to make this more clear, and changed it to “Error: please input a URL”.
> 
> 
> <img alt="Screen Shot 2023-05-07 at 11 58 45 AM" width="617" src="https://user-images.githubusercontent.com/36302020/236688636-66c0237a-edec-48ff-b52f-e5461c1ba433.png">
> 
> **Valid URL check:**
> 
>     * Used JS URL object to do an error check on the validity of the user inputted email. It only creates URLS for websites beginning with http or https. Before, it allows any string input even if it is not a URL (which technically isn't a big issue).
> 
> 
> <img alt="Screen Shot 2023-05-07 at 11 57 26 AM" width="671" src="https://user-images.githubusercontent.com/36302020/236688571-d1b608a7-2828-43ea-9a48-edd71fa39ebc.png">
> 
> **Background color:**
> 
>     * Added black background option and custom color background option. Suppose the poster is green, but they want the background of the QR code to be yellow. This eliminates the need for users to put the transparent background QR code on a colored square manually.
> 
> 
> <img alt="Screen Shot 2023-05-07 at 11 56 29 AM" width="560" src="https://user-images.githubusercontent.com/36302020/236688530-ae34c8db-e790-448b-9548-45710d6f60e4.png">
> 
> **Download as JPEG:**
> 
>     * Added a button to make the image downloadable as JPEG as well.
> 
> 
> <img alt="Screen Shot 2023-05-07 at 11 55 45 AM" width="606" src="https://user-images.githubusercontent.com/36302020/236688477-be9b44f3-9d51-49ca-8220-0489f14af259.png">

_________________
_________________
_________________

By HughChen:

> Thanks for the changes! Sorry I just now have some free time to revisit this. A few notes:
> 
> For the **background color picker**, this is awesome! One caveat is that I don't think users should be able to check multiple background colors simultaneously: <img alt="Screenshot 2023-05-23 at 5 28 56 PM" width="893" src="https://private-user-images.githubusercontent.com/3814434/240447915-156d5d64-7bf7-43bc-b08e-99a5718c0771.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NDc5ODgyNzUsIm5iZiI6MTc0Nzk4Nzk3NSwicGF0aCI6Ii8zODE0NDM0LzI0MDQ0NzkxNS0xNTZkNWQ2NC03YmY3LTQzYmMtYjA4ZS05OWE1NzE4YzA3NzEucG5nP1gtQW16LUFsZ29yaXRobT1BV1M0LUhNQUMtU0hBMjU2JlgtQW16LUNyZWRlbnRpYWw9QUtJQVZDT0RZTFNBNTNQUUs0WkElMkYyMDI1MDUyMyUyRnVzLWVhc3QtMSUyRnMzJTJGYXdzNF9yZXF1ZXN0JlgtQW16LURhdGU9MjAyNTA1MjNUMDgxMjU1WiZYLUFtei1FeHBpcmVzPTMwMCZYLUFtei1TaWduYXR1cmU9YjhmN2FjODIyNGZmOTM1Yjc0MTVlMmUyNmRlNmYyZTVmZDAzMDlhYTcxNjAzZTkyMmMyNjIwYjc4NDY4MTJhNyZYLUFtei1TaWduZWRIZWFkZXJzPWhvc3QifQ.KxgOZtZikS5X2HnE2tWZe6YsF5x3uS-2T_66Wq0vwyg">
> 
> Instead, I think removing the white background and black background options and leaving only the custom color picker and renaming it to "Custom background color" would be better. Let me know if you have any other thoughts around this!
> 
> As for the **valid URL check**, I actually think it is better to not have this check since technically encoding non-URLs in QR codes is a valid use case.
> 
> Finally, downloading the JPEG looks good.




